### PR TITLE
Fix Xray silent crashes and harden JSON config parsing

### DIFF
--- a/tester.py
+++ b/tester.py
@@ -156,6 +156,21 @@ async def test_batch_real_delay(batch_configs, batch_start_port, session, failur
         # Increased startup wait to ensure ports are bound
         await asyncio.sleep(1.0)
 
+        try:
+            # If it exits within 0.1s of checking, it crashed!
+            await asyncio.wait_for(process.wait(), timeout=0.1)
+            stderr_output = await process.stderr.read()
+            print(f"FATAL: Xray crashed on startup! Error: {stderr_output.decode()}")
+
+            # CRITICAL: Save the corrupted JSON to disk so we can debug it in the CI/CD artifacts!
+            with open(f"crashed_batch_{batch_start_port}.json", "w") as f:
+                f.write(config_json)
+
+            return [None] * len(batch_configs)
+        except asyncio.TimeoutError:
+            # Process is still running normally, proceed with aiohttp requests
+            pass
+
         # 3. Concurrent Requests (using shared session)
         tasks = []
         for i in range(len(parsed_batch)):

--- a/v2ray_utils.py
+++ b/v2ray_utils.py
@@ -127,7 +127,7 @@ def parse_vmess(vmess_url):
             "add": add,
             "port": int(data.get("port", 0)),
             "id": data.get("id", ""),
-            "aid": data.get("aid", "0"),
+            "aid": int(data.get("aid", "0")),
             "net": data.get("net", "tcp"),
             "type": data.get("type", "none"),
             "host": data.get("host", ""),
@@ -149,10 +149,15 @@ def parse_vless_trojan(url, protocol):
         add = sanitize_host(parsed.hostname)
         if not add: return None, f"{protocol}_InvalidHost"
 
+        try:
+            port = int(parsed.port)
+        except (ValueError, TypeError):
+            return None, f"{protocol}_InvalidPort"
+
         config = {
             "protocol": protocol,
             "add": add,
-            "port": parsed.port,
+            "port": port,
             "id": parsed.username,
             "net": params.get("type", ["tcp"])[0],
             "type": params.get("headerType", ["none"])[0], # for tcp
@@ -176,7 +181,7 @@ def parse_ss(url):
         port = parsed.port
 
         # Check if the whole authority is base64 encoded (old style)
-        if not host and not port and parsed.netloc:
+        if not user_info and not port and parsed.netloc:
              decoded = safe_decode(parsed.netloc)
              if '@' in decoded:
                  parts = decoded.split('@')
@@ -200,7 +205,7 @@ def parse_ss(url):
                  return {
                      "protocol": "shadowsocks",
                      "add": host,
-                     "port": port,
+                     "port": int(port),
                      "id": password,
                      "method": method,
                      "net": "tcp",
@@ -224,10 +229,15 @@ def parse_ss(url):
              host = sanitize_host(host)
              if not host: return None, "SS_InvalidHost"
 
+             try:
+                 port = int(port)
+             except (ValueError, TypeError):
+                 return None, "SS_InvalidPort"
+
              return {
                  "protocol": "shadowsocks",
                  "add": host,
-                 "port": port,
+                 "port": int(port),
                  "id": password,
                  "method": method,
                  "net": "tcp",
@@ -332,7 +342,7 @@ def _create_outbound_object(outbound_config, tag):
         outbound['settings'] = {
             "vnext": [{
                 "address": outbound_config['add'],
-                "port": outbound_config['port'],
+                "port": int(outbound_config['port']),
                 "users": [{
                     "id": outbound_config['id'],
                     "alterId": int(outbound_config.get('aid', 0)),
@@ -365,7 +375,7 @@ def _create_outbound_object(outbound_config, tag):
         outbound['settings'] = {
             "vnext": [{
                 "address": outbound_config['add'],
-                "port": outbound_config['port'],
+                "port": int(outbound_config['port']),
                 "users": [{
                     "id": outbound_config['id'],
                     "encryption": "none",
@@ -390,7 +400,7 @@ def _create_outbound_object(outbound_config, tag):
         outbound['settings'] = {
             "servers": [{
                 "address": outbound_config['add'],
-                "port": outbound_config['port'],
+                "port": int(outbound_config['port']),
                 "password": outbound_config['id']
             }]
         }
@@ -404,7 +414,7 @@ def _create_outbound_object(outbound_config, tag):
         outbound['settings'] = {
             "servers": [{
                 "address": outbound_config['add'],
-                "port": outbound_config['port'],
+                "port": int(outbound_config['port']),
                 "method": outbound_config.get('method', 'aes-256-gcm'),
                 "password": outbound_config['id']
             }]
@@ -431,7 +441,7 @@ def generate_xray_batch_config(batch_configs, start_port):
 
         # Create Inbound
         inbounds.append({
-            "port": local_port,
+            "port": int(local_port),
             "protocol": "http",
             "settings": {},
             "tag": inbound_tag,


### PR DESCRIPTION
This PR addresses the issue where Xray was crashing silently for many batches during the Real Delay testing phase. 

Changes:
1.  **`tester.py`**:
    *   Added a check using `asyncio.wait_for(process.wait(), timeout=0.1)` immediately after the 1.0s startup delay.
    *   If the process exits, it now logs the stderr output and saves the generated JSON configuration to a file (e.g., `crashed_batch_10000.json`). This allows for precise debugging of the configuration that caused the crash.
    *   Returns failure results for the batch immediately upon crash detection.

2.  **`v2ray_utils.py`**:
    *   **Parsing Hardening**: Updated `parse_vmess`, `parse_vless_trojan`, and `parse_ss` to strictly cast ports and `alterId` (for VMess) to integers. If casting fails (e.g., invalid port string), the parsing function now returns an error instead of a malformed config object.
    *   **Shadowsocks Parsing**: Improved `parse_ss` to better handle "old style" base64-encoded SIP002 URIs and "new style" userinfo-based URIs, ensuring ports are correctly extracted and validated in all cases.
    *   **Config Generation**: Updated `generate_xray_batch_config` and `_create_outbound_object` to include redundant `int()` casting for ports and IDs to ensure the final JSON is type-safe for Xray, even if upstream parsing missed something (though the parsing updates should catch it).

These changes ensure that invalid configurations are filtered out early, and if Xray does crash, we capture the reason and the offending configuration.

---
*PR created automatically by Jules for task [12509808528314301534](https://jules.google.com/task/12509808528314301534) started by @mobinsamadir*